### PR TITLE
Primarily added the functionality needed for dms/channel message embeds for server-related questions.

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -14,6 +14,7 @@
 			"port": 10093,
 			"token": "super secret token",
 			"color": 8912896
-		},
-	]
+		}
+	],
+	"faq_words": ["server", "servers", "ready", "when"]
 }

--- a/src/main/java/net/hashsploit/mediusdiscordbot/CommandEvent.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/CommandEvent.java
@@ -14,13 +14,14 @@ public class CommandEvent {
 	private final User issuer;
 	private final MessageChannel channel;
 	private final Command command;
-	private final List<String> arguments;
+
+	private final ArrayList<String> arguments;
 	
 	public CommandEvent(final User issuer, final MessageChannel channel, final Command command, final List<String> arguments) {
 		this.issuer = issuer;
 		this.channel = channel;
 		this.command = command;
-		this.arguments = new ArrayList<String>();
+		this.arguments = new ArrayList<>(arguments);
 	}
 
 	public void reply(String message) {
@@ -30,16 +31,26 @@ public class CommandEvent {
 	public void reply(MessageEmbed embed) {
 		this.channel.sendMessage(embed).complete();
 	}
-	
+
+	public void replyDM(String message) {
+		issuer.openPrivateChannel().queue(channel -> channel.sendMessage(message).queue());
+	}
+
+	public void replyDM(MessageEmbed embed) {
+		issuer.openPrivateChannel().queue(channel -> channel.sendMessage(embed).queue());
+	}
+
 	/**
 	 * Send a JSON Query Message  
 	 * @param server
 	 * @param payload
 	 */
 	public JSONObject sendJSONQueryMessage(String server, JSONObject payload) {
-		
-		
 		return null;
 	}
-	
+
+	public ArrayList<String> getArguments() {
+		return arguments;
+	}
+
 }

--- a/src/main/java/net/hashsploit/mediusdiscordbot/MediusBot.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/MediusBot.java
@@ -16,6 +16,7 @@ import net.dv8tion.jda.api.entities.Activity;
 import net.hashsploit.mediusdiscordbot.commands.ClearCommand;
 import net.hashsploit.mediusdiscordbot.commands.HelpCommand;
 import net.hashsploit.mediusdiscordbot.commands.ShutdownCommand;
+import net.hashsploit.mediusdiscordbot.commands.ServerStatusCommand;
 
 public class MediusBot {
 
@@ -51,6 +52,7 @@ public class MediusBot {
 		commands.add(new HelpCommand());
 		commands.add(new ShutdownCommand());
 		commands.add(new ClearCommand());
+		commands.add(new ServerStatusCommand());
 		
 		// Initialize JDA
 		try {

--- a/src/main/java/net/hashsploit/mediusdiscordbot/MediusBotConfig.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/MediusBotConfig.java
@@ -18,6 +18,7 @@ public class MediusBotConfig {
 	private String token;
 	private String prefix;
 	private HashSet<Long> operators;
+	private HashSet<String> faqWords;
 	private HashSet<MediusJQMServer> servers;
 	
 	public MediusBotConfig(JSONObject json) {
@@ -35,7 +36,16 @@ public class MediusBotConfig {
 			final long id = Long.parseLong(jsonOperatorIterator.next().toString());
 			operators.add(id);
 		}
-		
+
+		// Load faqWords
+		this.faqWords = new HashSet<String>();
+		final JSONArray jsonFaqWordsArray = json.getJSONArray("faq_words");
+		final Iterator<Object> jsonFaqWordsIterator = jsonFaqWordsArray.iterator();
+		while (jsonFaqWordsIterator.hasNext()) {
+			final String faqWord = jsonFaqWordsIterator.next().toString();
+			faqWords.add(faqWord);
+		}
+
 		// Load Server
 		this.servers = new HashSet<MediusJQMServer>();
 		final JSONArray jsonServerArray = json.getJSONArray("servers");
@@ -95,6 +105,10 @@ public class MediusBotConfig {
 	public void setOperators(HashSet<Long> operators) {
 		this.operators = operators;
 	}
+
+	public HashSet<String> getFaqWords(){ return this.faqWords; }
+
+	public void setFaqWords(HashSet<String> faqWords) { this.faqWords = faqWords; }
 
 	public HashSet<MediusJQMServer> getServers() {
 		return servers;

--- a/src/main/java/net/hashsploit/mediusdiscordbot/MessageListener.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/MessageListener.java
@@ -1,8 +1,6 @@
 package net.hashsploit.mediusdiscordbot;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,20 +15,25 @@ public class MessageListener extends ListenerAdapter {
 	
 	@Override
 	public void onMessageReceived(MessageReceivedEvent event) {
-		
+
+		boolean isFromPM = event.isFromType(ChannelType.PRIVATE);
+		boolean isBotMessage = event.getAuthor().getIdLong() == event.getJDA().getSelfUser().getIdLong();
+		boolean isMention = event.getMessage().getContentDisplay().startsWith("@" + event.getJDA().getSelfUser().getName());
+		boolean usesPrefix = event.getMessage().getContentRaw().startsWith(MediusBot.getInstance().getConfig().getPrefix());
+
 		// Log PM's and exit
-		if (event.isFromType(ChannelType.PRIVATE)) {
+		if (isFromPM) {
 			logger.info(String.format("[PM] %s: %s\n", event.getAuthor().getName(), event.getMessage().getContentDisplay()));
 			return;
 		}
-		
+
 		// Do not fire on our own messages
-		if (event.getAuthor().getIdLong() == event.getJDA().getSelfUser().getIdLong()) {
+		if (isBotMessage) {
 			return;
 		}
 		
 		// Parse by @mention
-		if (event.getMessage().getContentDisplay().startsWith("@" + event.getJDA().getSelfUser().getName())) {
+		if (isMention) {
 			final String message = event.getMessage().getContentDisplay().split("@" + event.getJDA().getSelfUser().getName())[1].trim();
 			final String[] parts = message.split(" ");
 			final String command = parts[0];
@@ -40,7 +43,7 @@ public class MessageListener extends ListenerAdapter {
 		}
 		
 		// Parse by prefix
-		if (event.getMessage().getContentRaw().startsWith(MediusBot.getInstance().getConfig().getPrefix())) {
+		if (usesPrefix) {
 			final String message = event.getMessage().getContentDisplay().split(MediusBot.getInstance().getConfig().getPrefix())[1];
 			final String[] parts = message.split(" ");
 			final String command = parts[0];
@@ -48,7 +51,20 @@ public class MessageListener extends ListenerAdapter {
 			
 			handleCommand(event, command, args);
 		}
-		
+
+		// Parse remaining messages and search for server status related inquiries
+		if (!isFromPM && !isBotMessage && !isMention && !usesPrefix){
+			HashSet<String> messageWords = new HashSet<String>(Arrays.asList(event.getMessage().getContentRaw().split(" ")));
+
+			if (!Collections.disjoint(messageWords, MediusBot.getInstance().getConfig().getFaqWords())) {
+				final String command = "serverStatus";
+				final String[] args = new String[]{"parsed"};
+
+				handleCommand(event, command, args);
+			}
+
+		}
+
 	}
 	
 	/**

--- a/src/main/java/net/hashsploit/mediusdiscordbot/commands/ServerStatusCommand.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/commands/ServerStatusCommand.java
@@ -1,0 +1,36 @@
+package net.hashsploit.mediusdiscordbot.commands;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.hashsploit.mediusdiscordbot.Command;
+import net.hashsploit.mediusdiscordbot.CommandEvent;
+
+import java.util.ArrayList;
+
+public class ServerStatusCommand extends Command {
+
+	private static final String COMMAND = "serverStatus";
+	private static final String DESCRIPTION = "Gives users information about the current server status in either a pm if parsed or in channel if called with prefix";
+
+	public ServerStatusCommand() { super(COMMAND, DESCRIPTION, false); }
+
+	@Override
+	public void onFire(CommandEvent event) {
+		ArrayList<String> args = event.getArguments();
+
+		EmbedBuilder eb = new EmbedBuilder();
+		eb.setTitle("Servers Status","https://status.uyaonline.com/");
+		eb.addField("", "The servers are not public yet!", false);
+		eb.addBlankField(false);
+		eb.addField("DL Online Status", "In closed-beta right now and restricted to users with the #dl-beta-testing role only. Managed by @Dnawrkshp#8266 .", true);
+		eb.addField("UYA Online Status", "UYA Online Status: In development and managed by @hashsploit#0001 .", true);
+
+		if (args.get(0).equals("parsed")){
+			event.replyDM(eb.build());
+		}
+		else {
+			event.reply(eb.build());
+		}
+
+	}
+	
+}


### PR DESCRIPTION
A bit rusty on Java so I tried to follow existing code semantics. 

One thing that needs to be discussed is what words should trigger the discord DM and how to avoid spamming the user in the case of related words.

Changes:	
- Add faq_words (type Array<String>) to json config file
- Add HashSet<String> faqWords and load faqWords section to MediusBotConfig.java
- Create new ServerStatusCommand.java file with ability to respond to parsed message and prefix invocation
- Add ServerStatusCommand to MediusBot.java command loader to respond to prefixed command and parsed message
- Add additional parser for non-prefixed, non-mentioned, non-bot, non-dm messages in the channels
- Add replyDM(String message), replyDM(MessageEmbed embed), and arguments getter methods to CommandEvent.java