### PR TITLE
Refactor previous changes

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,34 +1,38 @@
 {
-	"log_level": "INFO",
-	"token": "",
-	"prefix": "!",
-	"operators": [
-		000000000000000000,
-		123456789012345678
-	],
-	"default_color": 13158600,
-	"servers": [
-		{
-			"name": "dl",
-			"description": "Deadlocked",
-			"address": "127.0.0.1",
-			"port": 10093,
-			"token": "super secret token",
-			"color": 8912896
-		},
-		{
-			"name": "uya",
-			"description": "Up Your Arsenal",
-			"address": "127.0.0.1",
-			"port": 10093,
-			"token": "super secret token",
-			"color": 16755200
-		}
-	],
-	"faq_words": [
-		"server",
-		"servers",
-		"ready",
-		"when"
-	]
+    "log_level": "INFO",
+    "token": "",
+    "prefix": "!",
+    "operators": [000000000000000000, 123456789012345678],
+    "default_color": 13158600,
+    "default_command_icons": {
+        "help": "https://i.imgur.com/uLdPtjc.png",
+        "status": "https://i.imgur.com/Yo0Efh2.png"
+    },
+    "servers": [
+        {
+            "name": "dl",
+            "description": "Deadlocked",
+            "address": "127.0.0.1",
+            "port": 10093,
+            "token": "super secret token",
+            "color": 8912896,
+            "command_icons": {
+                "status": "https://i.imgur.com/N0AhWfe.png"
+            },
+            "static_status": "Server is currently under beta testing, and will be public soon."
+        },
+        {
+            "name": "uya",
+            "description": "Up Your Arsenal",
+            "address": "127.0.0.1",
+            "port": 10093,
+            "token": "super secret token",
+            "color": 16755200,
+            "command_icons": {
+                "status": "https://i.imgur.com/nc2eE2s.png"
+            },
+            "static_status": "Server is currently under development."
+        }
+    ],
+    "faq_words": ["server", "servers", "ready", "when"]
 }

--- a/src/main/java/net/hashsploit/mediusdiscordbot/MediusBotConfig.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/MediusBotConfig.java
@@ -21,6 +21,7 @@ public class MediusBotConfig {
 	private HashSet<Long> operators;
 	private int defaultColor;
 	private HashMap<String, MediusJQMServer> servers;
+	private HashMap<String, String> defaultCommandIcons;
 	private HashSet<String> faqWords;
 	
 	public MediusBotConfig(JSONObject json) {
@@ -49,6 +50,14 @@ public class MediusBotConfig {
 			faqWords.add(faqWord);
 		}
 
+		//Load default command icons
+		this.defaultCommandIcons = new HashMap<String, String>();
+		final JSONObject jsonDefaultCommandIcons = json.getJSONObject("default_command_icons");
+		final Iterator<String> jsonDefaultCommandIconsNameIter = jsonDefaultCommandIcons.keys();
+			while (jsonDefaultCommandIconsNameIter.hasNext()){
+				final String commandName = jsonDefaultCommandIconsNameIter.next();
+				this.defaultCommandIcons.put(commandName, jsonDefaultCommandIcons.getString(commandName));
+			}
 		// Load Server
 		this.servers = new HashMap<String, MediusJQMServer>();
 		final JSONArray jsonServerArray = json.getJSONArray("servers");
@@ -61,8 +70,18 @@ public class MediusBotConfig {
 			final int port = jsonServer.getInt("port");
 			final String token = jsonServer.getString("token");
 			final int color = jsonServer.getInt("color");
-			
-			final MediusJQMServer server = new MediusJQMServer(name, description, address, port, token, color);
+			final String staticStatus = jsonServer.has("static_status") ? jsonServer.getString("static_status") : null;
+
+			//Load specified command icons for server
+			final HashMap<String, String> commandIcons = new HashMap<String,String>();
+			final JSONObject jsonCmdIcons = jsonServer.getJSONObject("command_icons");
+			final Iterator<String> jsonCmdIconsNamesIter = jsonCmdIcons.keys();
+			while (jsonCmdIconsNamesIter.hasNext()){
+				final String commandName = jsonCmdIconsNamesIter.next();
+				commandIcons.put(commandName, jsonCmdIcons.getString(commandName));
+			}
+
+			final MediusJQMServer server = new MediusJQMServer(name, description, address, port, token, color, staticStatus, commandIcons);
 			servers.put(name, server);
 		}
 		
@@ -105,8 +124,8 @@ public class MediusBotConfig {
 		return defaultColor;
 	}
 
-	public int setDefaultColor(){
-		return defaultColor;
+	public void setDefaultColor(int defaultColor){
+		this.defaultColor = defaultColor;
 	}
 
 	public HashSet<Long> getOperators() {
@@ -117,7 +136,17 @@ public class MediusBotConfig {
 		this.operators = operators;
 	}
 
-	public HashSet<String> getFaqWords(){ return this.faqWords; }
+	public HashMap<String,String> getDefaultCommandIcons(){
+		return defaultCommandIcons;
+	}
+	
+	public void setDefaultCommandIcons(HashMap<String, String> defaultCommandIcons){
+		this.defaultCommandIcons = defaultCommandIcons;
+	}
+
+	public HashSet<String> getFaqWords(){ 
+		return this.faqWords; 
+	}
 
 	public void setFaqWords(HashSet<String> faqWords) { this.faqWords = faqWords; }
 

--- a/src/main/java/net/hashsploit/mediusdiscordbot/MediusJQMServer.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/MediusJQMServer.java
@@ -1,5 +1,7 @@
 package net.hashsploit.mediusdiscordbot;
 
+import java.util.HashMap;
+
 public class MediusJQMServer {
 	
 	private final String name;
@@ -8,17 +10,21 @@ public class MediusJQMServer {
 	private final int port;
 	private final String token;
 	private final int color;
+	private String staticStatus;
+	private final HashMap<String,String> commandIcons;
 	
 	private int cachedTotalPlayers;
 	private int cachedOnlinePlayers;
 	
-	public MediusJQMServer(final String name, final String description, final String address, final int port, final String token, final int color) {
+	public MediusJQMServer(final String name, final String description, final String address, final int port, final String token, final int color, final String staticStatus ,final HashMap<String, String> commandIcons) {
 		this.name = name;
 		this.description = description;
 		this.address = address;
 		this.port = port;
 		this.token = token;
 		this.color = color;
+		this.staticStatus = staticStatus;
+		this.commandIcons = commandIcons;
 	}
 
 	/**
@@ -93,5 +99,19 @@ public class MediusJQMServer {
 	 */
 	public int getColor() {
 		return color;
+	}
+
+	/**
+	 * Get the Medius JQM static status message.
+	 */
+	public String getStaticStatus(){
+		return staticStatus;
+	}
+	
+	/**
+	 * Get the Medius JQM server command icons.
+	 */
+	public HashMap<String, String> getCommandIcons(){
+		return commandIcons;
 	}
 }

--- a/src/main/java/net/hashsploit/mediusdiscordbot/commands/HelpCommand.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/commands/HelpCommand.java
@@ -18,28 +18,27 @@ public class HelpCommand extends Command {
 	@Override
 	public void onFire(CommandEvent event) {		
 		EmbedBuilder embed = new EmbedBuilder();
-		final String thumbnail = "https://i.imgur.com/uLdPtjc.png";
 
 		// can be used for showing last cache value
 		// OffsetDateTime timestamp = OffsetDateTime.now();
 
-		embed.addBlankField(false);//line break after top meta info
-
-		boolean issuerIsOperator = MediusBot.getInstance().isOperator(event.getIssuer().getIdLong());
 		for (final Command c : MediusBot.getInstance().getCommands()) {
-			if (!c.isOperatorCommand() || issuerIsOperator) {
+			if (!c.isOperatorCommand()) {
 				embed.addField('`' + c.getName() + '`', c.getDescription(), false);
+			}
+		}
+		if (MediusBot.getInstance().isOperator(event.getIssuer().getIdLong())){
+			for (final Command c : MediusBot.getInstance().getCommands()) {
+				if (c.isOperatorCommand()) {
+					embed.addField('`' + c.getName() + '`', c.getDescription(), false);
+				}
 			}
 		}
 		embed.setTitle(COMMAND);
 		embed.setDescription(DESCRIPTION );
+		embed.setThumbnail(MediusBot.getInstance().getConfig().getDefaultCommandIcons().get(COMMAND));
 		embed.setColor(MediusBot.getInstance().getConfig().getDefaultColor());
 		embed.setAuthor​(MediusBot.NAME, null, MediusBot.ICON);
-		embed.setThumbnail(thumbnail);
-		embed.setFooter​(MediusBot.NAME);
-
-		embed.addBlankField(false);//line break before footer section
-		embed.addField("", "[UYAOnline](https://uyaonline.com/)", true);
 		
 		event.reply(embed.build());
 	}

--- a/src/main/java/net/hashsploit/mediusdiscordbot/commands/StatusCommand.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/commands/StatusCommand.java
@@ -19,42 +19,41 @@ public class StatusCommand extends Command {
 		super(COMMAND, DESCRIPTION, false);
 	}
 
+	private String getStatus(MediusJQMServer server){
+		if (server.getStaticStatus() != null){
+			return server.getStaticStatus();
+		}
+
+		return "Server pinging under development!";
+	}
+	
 	@Override
 	public void onFire(CommandEvent event) {
 		EmbedBuilder embed = new EmbedBuilder();
 
 		List<String> args = event.getArguments();	//expect server names
 		HashMap<String, MediusJQMServer> servers = MediusBot.getInstance().getConfig().getServers();
-		HashMap<String, String> serverStatus = new HashMap<String, String>();
-		HashMap<String, String> thumbnails = new HashMap<String, String>();
 
-		serverStatus.put("uya", "Currently in development.");
-		thumbnails.put("uya", "https://i.imgur.com/nc2eE2s.png");
-
-		serverStatus.put("dl", "Currently in beta phase.");
-		thumbnails.put("dl", "https://i.imgur.com/N0AhWfe.png");
-
-
-		String thumbnail = "https://i.imgur.com/Yo0Efh2.png";	//default
+		String thumbnail = MediusBot.getInstance().getConfig().getDefaultCommandIcons().get(COMMAND);
 		int color = MediusBot.getInstance().getConfig().getDefaultColor();
-		if (args.size() == 1 && serverStatus.containsKey(args.get(0)) && servers.containsKey(args.get(0))){
-			thumbnail = thumbnails.get(args.get(0));
-			color = servers.get(args.get(0)).getColor();
-			embed.addField('`' + args.get(0) + '`', serverStatus.get(args.get(0)), false);
+		if (args.size() == 1 && servers.containsKey(args.get(0))){
+			final MediusJQMServer server = servers.get(args.get(0));
+			if (server.getCommandIcons().containsKey(COMMAND)){
+				thumbnail = server.getCommandIcons().get(COMMAND);
+			}
+			color = server.getColor();
+			embed.addField('`' + server.getName() + '`', getStatus(server), false);
 		} else {
-			for (Map.Entry<String, String> entry : serverStatus.entrySet()){
-				embed.addField('`' + entry.getKey() + '`', serverStatus.get(entry.getKey()), false);
+			embed.setDescription(DESCRIPTION);
+			for (MediusJQMServer server : servers.values()){
+				embed.addField('`' + server.getName() + '`', getStatus(server), false);
 			}
 		}
 		embed.setTitle("Servers Status", "https://status.uyaonline.com/");
-		embed.setDescription(DESCRIPTION);
+		embed.setThumbnail(thumbnail);
 		embed.setColor(color);
 		embed.setAuthor​(MediusBot.NAME, null, MediusBot.ICON);
-		embed.setThumbnail(thumbnail);
-		embed.setFooter​(MediusBot.NAME);
 
-		embed.addField("", "[UYAOnline](https://uyaonline.com/)", true);
-		
 		event.reply(embed.build());
 	}
 }


### PR DESCRIPTION
Tl;dr: Removed all hardcoding used in the status command, moving all command url's used and static status messages to the config file, and then parsing them. Help command also prints out non op commands, then op commands after. No more use of footers to cut down on space of an embed.

config.json:
- A new field `"default_command_icons"` is added, which is another json object of keys -> url mappings, each representing a command name and the command's respective icon. These are always default to be used on a command thumbnail unless a server specifies a different icon for a command.
- On each server, a new field `"command_icons"` is added, which is another json object of keys -> url mappings, each representing a command name and the command's respective icon.
- On each server, a new field `"static_status"` *may* be added, which denotes that on the `status` command, this will be displayed in place of a ping to the JQM server.

MediusJQMServer.java:
- Added a new field `private String staticStatus;`, which denotes that on the `status` command, this will be displayed in place of a ping to the JQM server.
- Added a new field `private final HashMap<String,String> commandIcons;`, which is a key, value pair where the key is the name of the command(String), and the value is a url to the respective command icon (String). The primary url source for a particular server's icon, if it exists.

MediusBotConfig.java:
- Added a new field `private HashMap<String, String> defaultCommandIcons;`, which is a key, value pair where the key is the name of the command(String), and the value is a url to the respective command icon (String). Used by default if command is not server specified, and as a fallback if a server does not have a specified icon for a command.
- When parsing servers, we handle the parsing of `"default_command_icons"`, creating a new hash map to populate the mappings of default command name to command icon url.
- When parsing servers, we handle the parsing of `"command_icons"`, creating a new hash map to populate the mappings of server specific command name to command icon url.

HelpCommand.java:
- Revert the output of commands to what it originally was; printing first non operator commands, and then operator commands.
- Remove extra lines, and remove footer.

StatusCommand.java:
- Remove new declarations of hashmaps for status/ thumbnails.
- Directly load icons from the config default/ server specified command icons.
- Check if we have a specified static message already pre-loaded in config.
- Add private method `getStatus(MediusJQMServer server)` to retrieve the status of the specified medius server.