### PR TITLE
Changes 10/1/2020

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config.json
 *.swp
 *.tmp
 run
+clearbuild

--- a/README.md
+++ b/README.md
@@ -10,37 +10,36 @@ stack directly in a standardized way.
 
 ## Features
 
-- [x] Handle user chat commands.
-- [ ] Send user chat messages.
-- [ ] Send JSON query messages to a compatible MLS.
-- [ ] JQM Players.
-- [ ] JQM Games.
-- [ ] JQM Rank (leaderboards).
-- [ ] Caching.
-
+-   [x] Handle user chat commands.
+-   [ ] Send user chat messages.
+-   [ ] Send JSON query messages to a compatible MLS.
+-   [ ] JQM Players.
+-   [ ] JQM Games.
+-   [ ] JQM Rank (leaderboards).
+-   [x] Caching.
 
 ## Configuration
 
 **Base Configuration:**
-| Name      | Type   | Description                                                                                                                                                           |
+| Name | Type | Description |
 |-----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| log_level | string | The log level to be used. Can be "TRACE, "DEBUG", "INFO", "WARNING", or "ERROR".                                                                                      |
-| token     | string | The Discord App Token which can be gotten from https://discord.com/developers/applications/                                                                           |
-| prefix    | string | Usually a character that this bot will listen to as a prefix for commands. This can be set to `null` to not listen to any prefix and instead listen to mentions only. |
-| operators | array  | An array of integer values that represent Discord User Id's who have full control of the bot.                                                                         |
-| servers   | array  | An array of Server Objects which have information regarding each Medius Server and component.                                                                         |
-
+| log_level | string | The log level to be used. Can be "TRACE, "DEBUG", "INFO", "WARNING", or "ERROR". |
+| token | string | The Discord App Token which can be gotten from https://discord.com/developers/applications/ |
+| prefix | string | Usually a character that this bot will listen to as a prefix for commands. This can be set to `null` to not listen to any prefix and instead listen to mentions only. |
+| operators | array | An array of integer values that represent Discord User Id's who have full control of the bot. |
+| default_color | int | The default embed theme color, represented as an integer. |
+| servers | array | An array of Server Objects which have information regarding each Medius Server and component. |
 
 **Server Objects:**
-| Name        | Type    | Description                                                     |
+| Name | Type | Description |
 |-------------|---------|-----------------------------------------------------------------|
-| name        | string  | A short string to represent this server, such as "dl" or "uya". |
-| description | string  | A full string representation of the server name.                |
-| address     | string  | The IP Address of the Medius Lobby Server JSON query API.       |
-| port        | integer | The port of the Medius Lobby Server JSON query API.             |
-| token       | string  | The pre-shared secret token used to access the JSON query API.  |
-| color       | integer | The color to use for embedded messages.                         |
-
+| name | string | A short string to represent this server, such as "dl" or "uya". |
+| description | string | A full string representation of the server name. |
+| address | string | The IP Address of the Medius Lobby Server JSON query API. |
+| port | integer | The port of the Medius Lobby Server JSON query API. |
+| token | string | The pre-shared secret token used to access the JSON query API. |
+| color | integer | The color to use for embedded messages. |
+| command_icons | A json object containing custom discord embed thumbnail URL's |
 
 ## Commands
 
@@ -48,90 +47,120 @@ Here is a list of common bot commands.
 All optional parameters are defined with **[square brackets]**.
 While all required parameters are defined with **<angle brackets>**.
 
-
 #### Common user commands:
-- `help [command]` - Show all commands, or show information about a specific command. Example: `!help players`.
-- `servers` - Show a list of available Medius servers. Example: `!servers`.
-- `status [server name]` - Show server status. Example: `!status` or `!status dl`.
-- `players <server name>` - Show all currently connected players on `server`. Example: `!players dl`.
-- `games <server name>` - Show all game statuses. Example: `!games dl`.
-- `rank <server name> [player]` - Show the current command issuer's username/nick's rank. If the username is not found or the issuer name is not a valid player in game the optional **[player]** parameter should be used. Example: `!rank dl Reconker`.
 
+-   `help [command]` - Show all commands, or show information about a specific command. Example: `!help players`.
+-   `servers` - Show a list of available Medius servers. Example: `!servers`.
+-   `status [server name]` - Show server status. Example: `!status` or `!status dl`.
+-   `players <server name>` - Show all currently connected players on `server`. Example: `!players dl`.
+-   `games <server name>` - Show all game statuses. Example: `!games dl`.
+-   `rank <server name> [player]` - Show the current command issuer's username/nick's rank. If the username is not found or the issuer name is not a valid player in game the optional **[player]** parameter should be used. Example: `!rank dl Reconker`.
 
 #### Operator commands:
-- `shutdown` - Gracefully shutdown the bot.
-- `clear <amount> [#channel] [@user]` - Clear chat messages of a specific amount in the current issuer's channel or of an optional channel of an optional user.
-- `broadcast <server name> <message>` - Send an in-game broadcast to all players on a specific server (Medius System Message).
-- `send <server name> <player> <msg>` - Send an in-game message to a specific player on a specific server (Medius System Message).
-- `kick <server name> <player>` - Kick a player from the server.
 
+-   `shutdown` - Gracefully shutdown the bot.
+-   `clear <amount> [#channel] [@user]` - Clear chat messages of a specific amount in the current issuer's channel or of an optional channel of an optional user.
+-   `broadcast <server name> <message>` - Send an in-game broadcast to all players on a specific server (Medius System Message).
+-   `send <server name> <player> <msg>` - Send an in-game message to a specific player on a specific server (Medius System Message).
+-   `kick <server name> <player>` - Kick a player from the server.
 
 ## Building/Compiling
 
 To build the project simply use `./build.sh` and to run the project use `./launch.sh`.
 
-
 ## JSON Query Messages Protocol
 
-The communication protocol between the Medius Lobby Server component and the bot use JSON query messages.
-All response messages may include an optional `additional_message` field of type `string` which is appended to the chat message.
-
+The communication protocol between the Medius Lobby Server component and the bot use JSON query messages. JSON query message interactions are done using HTTP POST requests. All response messages may include an optional `additional_message` field of type `string` which is appended to the chat message.
 
 ### Broadcast
 
 Show a list of players and basic player information.
 
 ###### Request
+
 ```json
 {
-	"query": "broadcast",
-	"message": "Server Restarting. We'll be right back!"
+    "query": "broadcast",
+    "message": "Server Restarting. We'll be right back!"
 }
 ```
 
 ###### Response
+
 ```json
 {
-	"success": true
+    "success": true
 }
 ```
-
 
 ### Players
 
 Show a list of players and basic player information.
 
 ###### Request
+
 ```json
 {
-	"query": "players"
+    "query": "players"
 }
 ```
 
 ###### Response
 
-- `total` is the total numbers of users registered.
+-   `total` is the total numbers of users registered.
 
 ```json
 {
-	"total": 10,
-	"players": [
-		{
-			"player_id": 1,
-			"player_name": "hashsploit",
-			"in_game": false
-		},
-		{
-			"player_id": 2,
-			"player_name": "Dnawrkshp",
-			"in_game": true
-		},
-		{
-			"player_id": 3,
-			"player_name": "Badger41",
-			"in_game": true
-		}
-	],
+    "total": 10,
+    "players": [
+        {
+            "player_id": 1,
+            "player_name": "hashsploit",
+            "in_game": false
+        },
+        {
+            "player_id": 2,
+            "player_name": "Dnawrkshp",
+            "in_game": true
+        },
+        {
+            "player_id": 3,
+            "player_name": "Badger41",
+            "in_game": true
+        }
+    ]
+}
+```
+
+### Status
+
+Sends a JSON object of the status of each server in each medius stack, with each stack's information being a separate JSON object.
+
+###### Request
+
+```json
+{
+    "query": "status"
+}
+```
+
+###### Response
+
+```json
+{
+    "uya": {
+        "UYA Online Website": true,
+        "UYA Medius Universe Information Server": false,
+        "UYA Medius Authentication Server": true,
+        "UYA Medius Lobby Server": false,
+        "UYA Medius Proxy Server": true
+    },
+    "dl": {
+        "DL Online Website": true,
+        "DL Medius Universe Information Server": false
+        // ...
+    }
+    //...
 }
 ```
 
@@ -140,66 +169,62 @@ Show a list of players and basic player information.
 Show a list of active games staged or in-progress.
 
 ###### Request
+
 ```json
 {
-	"query": "games"
+    "query": "games"
 }
 ```
 
 ###### Response
 
-- `extra_info` is an object that takes Key-Value pair string values for additional game information, this allows this bot to be used for other Medius titles as well.
+-   `extra_info` is an object that takes Key-Value pair string values for additional game information, this allows this bot to be used for other Medius titles as well.
 
 ```json
 {
-	"staging": [
-		{
-			"game_id": 302,
-			"game_name": "Dnawrkshp's",
-			"host": {
-				"player_id": 2,
-				"player_name": "Dnawrkshp"
-			},
-			"extra_info": {
-				"time": "15:00 Minutes",
-				"weapons": "Fusion Rifle, B6, Magma Cannon",
-				"type": "King of The Hill",
-				"map": "Maraxus Prison"
-			},
-		}
-	],
-	"in_progress": [
-		{
-			"game_id": 301,
-			"game_name": "hashsploit's",
-			"host": {
-				"player_id": 1,
-				"player_name": "hashsploit"
-			},
-			"extra_info": {
-				"time": "Infinate",
-				"weapons": "All",
-				"type": "CTF",
-				"map": "Sarathros"
-			},
-			"players": [
-				{
-					"player_id": 1,
-					"player_name": "hashsploit",
-					"host": true
-				},
-				{
-					"player_id": 45,
-					"player_name": "Reconker",
-					"host": false
-				},
-			],
-		}
-	],
+    "staging": [
+        {
+            "game_id": 302,
+            "game_name": "Dnawrkshp's",
+            "host": {
+                "player_id": 2,
+                "player_name": "Dnawrkshp"
+            },
+            "extra_info": {
+                "time": "15:00 Minutes",
+                "weapons": "Fusion Rifle, B6, Magma Cannon",
+                "type": "King of The Hill",
+                "map": "Maraxus Prison"
+            }
+        }
+    ],
+    "in_progress": [
+        {
+            "game_id": 301,
+            "game_name": "hashsploit's",
+            "host": {
+                "player_id": 1,
+                "player_name": "hashsploit"
+            },
+            "extra_info": {
+                "time": "Infinate",
+                "weapons": "All",
+                "type": "CTF",
+                "map": "Sarathros"
+            },
+            "players": [
+                {
+                    "player_id": 1,
+                    "player_name": "hashsploit",
+                    "host": true
+                },
+                {
+                    "player_id": 45,
+                    "player_name": "Reconker",
+                    "host": false
+                }
+            ]
+        }
+    ]
 }
 ```
-
-
-
-
-

--- a/config.json.example
+++ b/config.json.example
@@ -18,8 +18,7 @@
             "color": 8912896,
             "command_icons": {
                 "status": "https://i.imgur.com/N0AhWfe.png"
-            },
-            "static_status": "Server is currently under beta testing, and will be public soon."
+            }
         },
         {
             "name": "uya",

--- a/src/main/java/net/hashsploit/mediusdiscordbot/Command.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/Command.java
@@ -1,15 +1,19 @@
 package net.hashsploit.mediusdiscordbot;
 
+import net.hashsploit.mediusdiscordbot.util.TimedHashmap;
+
 public abstract class Command implements ICommand {
 	
 	private final String name;
 	private final String description;
 	private final boolean operatorCmd;
+	private final TimedHashmap<String, String> JQMServerCache;
 	
-	public Command(final String name, final String description, final boolean operatorCmd) {
+	public Command(final String name, final String description, final boolean operatorCmd, final TimedHashmap<String, String> JQMServerCache) {
 		this.name = name;
 		this.description = description;
 		this.operatorCmd = operatorCmd;
+		this.JQMServerCache = JQMServerCache;
 	}
 	
 	/**
@@ -26,6 +30,14 @@ public abstract class Command implements ICommand {
 	 */
 	public String getDescription() {
 		return description;
+	}
+
+	/**
+	 * Get the command description.
+	 * @return
+	 */
+	public TimedHashmap<String, String> getJQMServerCache() {
+		return JQMServerCache;
 	}
 	
 	/**

--- a/src/main/java/net/hashsploit/mediusdiscordbot/commands/BroadcastCommand.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/commands/BroadcastCommand.java
@@ -2,6 +2,7 @@ package net.hashsploit.mediusdiscordbot.commands;
 
 import net.hashsploit.mediusdiscordbot.Command;
 import net.hashsploit.mediusdiscordbot.CommandEvent;
+import net.hashsploit.mediusdiscordbot.util.TimedHashmap;
 
 public class BroadcastCommand extends Command {
 
@@ -9,14 +10,11 @@ public class BroadcastCommand extends Command {
 	public static final String DESCRIPTION = "Broadcast a message to all users on a specific server.";
 	
 	public BroadcastCommand() {
-		super(COMMAND, DESCRIPTION, true);
+		super(COMMAND, DESCRIPTION, true, new TimedHashmap<String,String>());
 	}
 
 	@Override
 	public void onFire(CommandEvent event) {
-		
-		
-		
 	}
 	
 	

--- a/src/main/java/net/hashsploit/mediusdiscordbot/commands/ClearCommand.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/commands/ClearCommand.java
@@ -2,6 +2,7 @@ package net.hashsploit.mediusdiscordbot.commands;
 
 import net.hashsploit.mediusdiscordbot.Command;
 import net.hashsploit.mediusdiscordbot.CommandEvent;
+import net.hashsploit.mediusdiscordbot.util.TimedHashmap;
 
 public class ClearCommand extends Command {
 
@@ -11,7 +12,7 @@ public class ClearCommand extends Command {
 	private boolean isWorking;
 	
 	public ClearCommand() {
-		super(COMMAND, DESCRIPTION, true);
+		super(COMMAND, DESCRIPTION, true, new TimedHashmap<String,String>());
 		isWorking = false;
 	}
 

--- a/src/main/java/net/hashsploit/mediusdiscordbot/commands/HelpCommand.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/commands/HelpCommand.java
@@ -5,14 +5,14 @@ import net.hashsploit.mediusdiscordbot.CommandEvent;
 import net.hashsploit.mediusdiscordbot.MediusBot;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed.Field;
-
+import net.hashsploit.mediusdiscordbot.util.TimedHashmap;
 public class HelpCommand extends Command {
 
 	public static final String COMMAND = "help";
 	public static final String DESCRIPTION = "Show a list of commands";
 
 	public HelpCommand() {
-		super(COMMAND, DESCRIPTION, false);
+		super(COMMAND, DESCRIPTION, false, new TimedHashmap<String,String>());
 	}
 
 	@Override

--- a/src/main/java/net/hashsploit/mediusdiscordbot/commands/ShutdownCommand.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/commands/ShutdownCommand.java
@@ -3,6 +3,7 @@ package net.hashsploit.mediusdiscordbot.commands;
 import net.hashsploit.mediusdiscordbot.Command;
 import net.hashsploit.mediusdiscordbot.CommandEvent;
 import net.hashsploit.mediusdiscordbot.MediusBot;
+import net.hashsploit.mediusdiscordbot.util.TimedHashmap;
 
 public class ShutdownCommand extends Command {
 
@@ -10,7 +11,7 @@ public class ShutdownCommand extends Command {
 	public static final String DESCRIPTION = "Shutdown the Bot";
 	
 	public ShutdownCommand() {
-		super(COMMAND, DESCRIPTION, true);
+		super(COMMAND, DESCRIPTION, true, new TimedHashmap<String,String>());
 	}
 	
 	@Override

--- a/src/main/java/net/hashsploit/mediusdiscordbot/commands/StatusCommand.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/commands/StatusCommand.java
@@ -26,6 +26,7 @@ public class StatusCommand extends Command {
 		super(COMMAND, DESCRIPTION, false, new TimedHashmap<String,String>());
 	}
 
+	//need to not make the url hardcoded! change in config!
 	private CompletableFuture<String> getStatus(){
 		CompletableFuture<String> res = new CompletableFuture<String>();
 		if (!this.getJQMServerCache().containsKey("status")){

--- a/src/main/java/net/hashsploit/mediusdiscordbot/commands/StatusCommand.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/commands/StatusCommand.java
@@ -1,59 +1,126 @@
 package net.hashsploit.mediusdiscordbot.commands;
 
 import java.util.List;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import org.json.JSONObject;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.hashsploit.mediusdiscordbot.Command;
 import net.hashsploit.mediusdiscordbot.CommandEvent;
 import net.hashsploit.mediusdiscordbot.MediusBot;
 import net.hashsploit.mediusdiscordbot.MediusJQMServer;
+import net.hashsploit.mediusdiscordbot.util.TimedHashmap;
+import net.hashsploit.mediusdiscordbot.util.HTTPRequestor;
+import java.net.http.HttpResponse;
 
 public class StatusCommand extends Command {
 
 	public static final String COMMAND = "status";
-	public static final String DESCRIPTION = "Gives users information about the current server status in either a pm if parsed or in channel if called with prefix";
+	public static final String DESCRIPTION = "Gives users information about the current server status in either a pm if parsed or in channel if called with prefix.";
 
 	public StatusCommand() {
-		super(COMMAND, DESCRIPTION, false);
+		super(COMMAND, DESCRIPTION, false, new TimedHashmap<String,String>());
 	}
 
-	private String getStatus(MediusJQMServer server){
-		if (server.getStaticStatus() != null){
-			return server.getStaticStatus();
+	private CompletableFuture<String> getStatus(){
+		CompletableFuture<String> res = new CompletableFuture<String>();
+		if (!this.getJQMServerCache().containsKey("status")){
+				final String body = new JSONObject().put("query", "status").toString();
+				HTTPRequestor client = new HTTPRequestor("http://localhost:3000", body, new ArrayList<String>(), 30);
+				client.makeRequest()
+				.thenApply( (String serverRes) -> {
+					this.getJQMServerCache().put("status", serverRes);
+					res.complete(serverRes);
+					return serverRes;
+				});
+		} else {
+			res.complete(this.getJQMServerCache().get("status"));
 		}
-
-		return "Server pinging under development!";
+		return res;
 	}
 	
+	private HashMap<String, Boolean> parseServerStatuses(JSONObject jsonServer){
+		HashMap<String, Boolean> statuses = new HashMap<String, Boolean>();
+
+		final Iterator<String> jsonRESTServerStatusesIter = jsonServer.keys();
+		while(jsonRESTServerStatusesIter.hasNext()){
+			final String MediusServerName = jsonRESTServerStatusesIter.next();
+			statuses.put(MediusServerName, new Boolean(jsonServer.getBoolean(MediusServerName)));
+		}
+
+		return statuses;
+	}
+
 	@Override
 	public void onFire(CommandEvent event) {
 		EmbedBuilder embed = new EmbedBuilder();
 
+		final String checkEmoji = "✅";
+		final String xEmoji = "❌";
 		List<String> args = event.getArguments();	//expect server names
 		HashMap<String, MediusJQMServer> servers = MediusBot.getInstance().getConfig().getServers();
+		// embed.setDescription(DESCRIPTION);
+		getStatus()
+		.thenAccept((String statusRes) -> {
+			String thumbnail = MediusBot.getInstance().getConfig().getDefaultCommandIcons().get(COMMAND);
+			int color = MediusBot.getInstance().getConfig().getDefaultColor();
 
-		String thumbnail = MediusBot.getInstance().getConfig().getDefaultCommandIcons().get(COMMAND);
-		int color = MediusBot.getInstance().getConfig().getDefaultColor();
-		if (args.size() == 1 && servers.containsKey(args.get(0))){
-			final MediusJQMServer server = servers.get(args.get(0));
-			if (server.getCommandIcons().containsKey(COMMAND)){
-				thumbnail = server.getCommandIcons().get(COMMAND);
-			}
-			color = server.getColor();
-			embed.addField('`' + server.getName() + '`', getStatus(server), false);
-		} else {
-			embed.setDescription(DESCRIPTION);
-			for (MediusJQMServer server : servers.values()){
-				embed.addField('`' + server.getName() + '`', getStatus(server), false);
-			}
-		}
-		embed.setTitle("Servers Status", "https://status.uyaonline.com/");
-		embed.setThumbnail(thumbnail);
-		embed.setColor(color);
-		embed.setAuthor​(MediusBot.NAME, null, MediusBot.ICON);
+			JSONObject jsonRESTServerStatusRes = new JSONObject(statusRes);
 
-		event.reply(embed.build());
+			// client queries for one particular server
+			if (args.size() == 1 && servers.containsKey(args.get(0))){
+				final MediusJQMServer server = servers.get(args.get(0));
+
+				if (server.getCommandIcons().containsKey(COMMAND)){
+					thumbnail = server.getCommandIcons().get(COMMAND);
+				}
+
+				color = server.getColor();
+
+				//check first if we have a static status instead of a web res
+				if (server.getStaticStatus() != null){
+					embed.addField("**" + server.getName() + "**", server.getStaticStatus(), false);
+				} else {
+					HashMap<String, Boolean> statuses = parseServerStatuses(jsonRESTServerStatusRes.getJSONObject(server.getName()));
+
+					for (String mediusServer : statuses.keySet()){
+						embed.addField( (statuses.get(mediusServer).booleanValue() ? checkEmoji : xEmoji) + " **" + mediusServer + "**", "", false);
+					}
+				}
+			} else {
+				//client does an incorrect/ general query
+				for (MediusJQMServer server : servers.values()){ 
+					//check first if we have a static status instead of a web res
+					if (server.getStaticStatus() != null){
+						embed.addField("**" + server.getName() + "**", server.getStaticStatus(), false);
+						continue;
+					}
+
+					HashMap<String, Boolean> statuses = parseServerStatuses(jsonRESTServerStatusRes.getJSONObject(server.getName()));
+					boolean allHealthy = true;
+
+					for (String mediusServer : statuses.keySet()){
+						if (statuses.get(mediusServer).booleanValue() == false){
+							allHealthy = false;
+							break;
+						}
+					}
+
+					embed.addField((allHealthy ? checkEmoji : xEmoji) + " **" + server.getName() + "**", "" , false);
+				}
+
+				embed.setDescription(DESCRIPTION);
+				embed.addField("For detailed information, enter a specific server name.", "", false);
+			}
+
+			embed.setTitle("Servers Status", "https://status.uyaonline.com/");
+			embed.setThumbnail(thumbnail);
+			embed.setColor(color);
+			event.reply(embed.build());
+		});
 	}
 }

--- a/src/main/java/net/hashsploit/mediusdiscordbot/util/HTTPRequestor.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/util/HTTPRequestor.java
@@ -1,0 +1,53 @@
+package net.hashsploit.mediusdiscordbot.util;
+
+import java.util.List;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.net.URI;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletableFuture;
+
+public class HTTPRequestor{
+    String uri;
+    String body;
+    List<String> headers;
+    int timeout;
+    
+    public HTTPRequestor(String uri, String body, List<String> headers, int timeout){
+        this.uri = uri;
+        this.body = body;
+        this.headers = headers;
+        this.timeout = timeout;
+    }
+
+    public CompletableFuture<String> makeRequest(){
+        HttpClient client = HttpClient.newBuilder()
+        .build();
+        
+        HttpRequest req = HttpRequest.newBuilder()
+        .uri(URI.create(this.uri))
+        .timeout(Duration.ofMinutes(this.timeout))
+        .POST(BodyPublishers.ofByteArray(body.getBytes()))
+        .build();
+        
+        CompletableFuture<String> res = new CompletableFuture<String>();
+
+        try{
+            client.sendAsync(req, BodyHandlers.ofString())
+            .thenAccept((HttpResponse serverRes) -> {
+                if (serverRes.statusCode() != 200){
+                    res.complete(null);
+                } 
+                res.complete(serverRes.body().toString());
+            });
+        } catch(Exception err){
+            res.complete(null);
+        }
+
+        return res;
+    }
+}

--- a/src/main/java/net/hashsploit/mediusdiscordbot/util/Pair.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/util/Pair.java
@@ -1,0 +1,19 @@
+package net.hashsploit.mediusdiscordbot;
+
+public class Pair<A,B>{
+    private A first;
+    private B second;
+
+    public Pair(A first, B second){
+        this.first = first;
+        this.second = second;
+    }
+
+    public A getFirst(){
+        return this.first;
+    }
+
+    public B getSecond(){
+        return this.second;
+    }
+}

--- a/src/main/java/net/hashsploit/mediusdiscordbot/util/TimedHashmap.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/util/TimedHashmap.java
@@ -1,0 +1,42 @@
+package net.hashsploit.mediusdiscordbot.util;
+
+import net.hashsploit.mediusdiscordbot.Pair;
+import java.util.HashMap;
+import java.time.LocalDateTime;
+import java.lang.NullPointerException;
+
+public class TimedHashmap <K,V> {
+    private HashMap<K, Pair<LocalDateTime,V>> hashmap;
+    private int expireSeconds;
+
+    public TimedHashmap(){
+        this.expireSeconds = 60*5;
+        hashmap = new HashMap<K, Pair<LocalDateTime,V>>();
+    }
+
+    public TimedHashmap(int expireSeconds){
+        this.expireSeconds = expireSeconds;
+        hashmap = new HashMap<K, Pair<LocalDateTime,V>>();
+    }
+
+    public void put(K key, V val){
+        hashmap.put(key, new Pair<LocalDateTime, V>(LocalDateTime.now(), val));
+    }
+
+    public V get(K key) throws NullPointerException{
+        if (!containsKey(key)){
+            throw new NullPointerException();
+        }
+        return hashmap.get(key).getSecond();
+    }
+
+    public boolean containsKey(K key){
+        if (!hashmap.containsKey(key)){
+            return false;
+        }
+
+        LocalDateTime currTime = hashmap.get(key).getFirst();
+
+        return currTime.plusSeconds(this.expireSeconds).isBefore(LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
Added:
- TimedHashmap.java: A wrapped JavaHashmap that has an auto expire time on elements, set by default currently to 5 minutes if a time is not specified.
- Pair.java: A basic generic pair, used currently mainly as a helper for TimedHashmap
- HTTPRequestor.java: A wrapper to basic java html requests. Expects meta information for a conneciton establishment on intantiation, and when a request is ready to be made to the url, the method `makeRequest()` can be called to create a new `CompletableFuture`, which returns the json response from the server as a string.

Modified:
- Command.java: A new private attribute, `TimedHashmap<String, String> JQMServerCache>` has been added for caching.
	- The constructor has been modified to expect a `TimedHashmap<String, String>` object to used to set JQMServerCache]
- BroadcastCommand.java: Added a new `TimedHashmap<String,String>` object to constructor for the super constructor call. Refer to changes in Command.java
- ClearCommand.java: Added a new `TimedHashmap<String,String>` object to constructor for the super constructor call. Refer to changes in Command.java
- HelpCommand.java: Added a new `TimedHashmap<String,String>` object to constructor for the super constructor call. Refer to changes in Command.java
- ShutdownCommand.java: Added a new `TimedHashmap<String,String>` object to constructor for the super constructor call. Refer to changes in Command.java
- StatusCommand.java: Entirely reworked. The command now has the ability to make a POST HTTPRequest to a url, which creates a JSON object with the field query, and value of status. This response is stored in the timed cache, with the key "status". Every response is then parsed on a per medius stack basis, and the status of each server in the medius stack will map to either true or false. If a single status query is ran, such as `!status uya`, the details of each server from the medius stack for UYA are displayed, and if a general query is used, only whether or not all of the servers in each stack is healthy or not. All operations blocked by network calls are done using `CompletableFuture<T>` to avoid synchronous code.
	- `private CompletableFuture<String> getStatus()`: Retrieves the status of each medius stack. If not found in the queue, an HTTP Post request is queried to the correct endpoint given in the configuration (TODO) and then cached in the commands timed cache, under the field "status". When complete, the CompletableFuture sets itself to complete with the response from the server.
	- `private HashMap<String, Boolean> parseServerStatuses(JSONObject jsonServer)`: Given a json object of a medius stack's statuses, it parses the JSON object into a HashMap of string keys to bool values, which is used for easy embed value creating for a response to the discord client.
- README.md: Update the config file fields. Add current information of status command.