### PR TITLE
Modify existing code to replace REST design to GRPC (incomplete):

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,13 @@
 	<description>Medius Discord Bot</description>
 	<packaging>jar</packaging>
 	<build>
+	<extensions>
+		<extension>
+			<groupId>kr.motd.maven</groupId>
+			<artifactId>os-maven-plugin</artifactId>
+			<version>1.6.2</version>
+		</extension>
+	</extensions>
 		<resources>
 			<resource>
 				<filtering>true</filtering>
@@ -38,6 +45,24 @@
 						</manifest>
 					</archive>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.xolstice.maven.plugins</groupId>
+				<artifactId>protobuf-maven-plugin</artifactId>
+				<version>0.6.1</version>
+				<configuration>
+					<protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
+					<pluginId>grpc-java</pluginId>
+					<pluginArtifact>io.grpc:protoc-gen-grpc-java:1.34.0:exe:${os.detected.classifier}</pluginArtifact>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compile</goal>
+							<goal>compile-custom</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>
@@ -85,5 +110,29 @@
 			<artifactId>logback-classic</artifactId>
 			<version>1.2.3</version>
 		</dependency>
+		
+		<dependency>
+		    <groupId>io.grpc</groupId>
+		    <artifactId>grpc-netty-shaded</artifactId>
+		    <version>1.34.0</version>
+		</dependency>
+		<dependency>
+		    <groupId>io.grpc</groupId>
+		    <artifactId>grpc-protobuf</artifactId>
+		    <version>1.34.0</version>
+		</dependency>
+		<dependency>
+		    <groupId>io.grpc</groupId>
+		    <artifactId>grpc-stub</artifactId>
+		    <version>1.34.0</version>
+		</dependency>
+		<dependency>
+		    <!-- necessary for Java 9+ -->
+		    <groupId>org.apache.tomcat</groupId>
+		    <artifactId>annotations-api</artifactId>
+		    <version>6.0.53</version>
+		    <scope>provided</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/proto/medius_structures.proto
+++ b/proto/medius_structures.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+service MediusInformationServer{
+    rpc GetStatus(StatusReq) returns (StatusRes) {}
+}
+
+message StatusReq{
+    optional repeated string serverNames = 1;
+}
+
+message StatusRes{
+    repeated StatusListing serverStatuses = 1;
+
+message StatusListing{
+    string serverName = 1;
+    int serverActive = 2;   //0 = inactive, 1 = active
+}

--- a/src/main/java/net/hashsploit/mediusdiscordbot/Command.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/Command.java
@@ -7,13 +7,13 @@ public abstract class Command implements ICommand {
 	private final String name;
 	private final String description;
 	private final boolean operatorCmd;
-	private final TimedHashmap<String, String> JQMServerCache;
+	private final TimedHashmap<String, String> GRPCServerCache;
 	
-	public Command(final String name, final String description, final boolean operatorCmd, final TimedHashmap<String, String> JQMServerCache) {
+	public Command(final String name, final String description, final boolean operatorCmd, final TimedHashmap<String, String> GRPCServerCache) {
 		this.name = name;
 		this.description = description;
 		this.operatorCmd = operatorCmd;
-		this.JQMServerCache = JQMServerCache;
+		this.GRPCServerCache = GRPCServerCache;
 	}
 	
 	/**
@@ -36,8 +36,8 @@ public abstract class Command implements ICommand {
 	 * Get the command description.
 	 * @return
 	 */
-	public TimedHashmap<String, String> getJQMServerCache() {
-		return JQMServerCache;
+	public TimedHashmap<String, String> getGRPCServerCache() {
+		return GRPCServerCache;
 	}
 	
 	/**

--- a/src/main/java/net/hashsploit/mediusdiscordbot/MediusBot.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/MediusBot.java
@@ -17,6 +17,7 @@ import net.hashsploit.mediusdiscordbot.commands.ClearCommand;
 import net.hashsploit.mediusdiscordbot.commands.HelpCommand;
 import net.hashsploit.mediusdiscordbot.commands.ShutdownCommand;
 import net.hashsploit.mediusdiscordbot.commands.StatusCommand;
+import net.hashsploit.mediusdiscordbot.MediusInformationClient;
 
 public class MediusBot {
 
@@ -26,9 +27,10 @@ public class MediusBot {
 	public static final String ICON = "https://upload.wikimedia.org/wikipedia/en/2/22/All_4_One_-_Clank.png";
 	private static MediusBot bot;
 	
+	
 	public MediusBotConfig config;
 	public HashSet<Command> commands;
-	public JDA jda;
+	public JDA jda; 
 
 	public MediusBot(JSONObject json) {
 		
@@ -54,7 +56,7 @@ public class MediusBot {
 		commands.add(new ShutdownCommand());
 		commands.add(new ClearCommand());
 		commands.add(new StatusCommand());
-		
+
 		// Initialize JDA
 		try {
 			jda = JDABuilder.createLight(config.getToken())

--- a/src/main/java/net/hashsploit/mediusdiscordbot/MediusBotConfig.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/MediusBotConfig.java
@@ -20,9 +20,9 @@ public class MediusBotConfig {
 	private String prefix;
 	private HashSet<Long> operators;
 	private int defaultColor;
-	private HashMap<String, MediusJQMServer> servers;
+	private HashMap<String, MediusInformationClient> servers;
 	private HashMap<String, String> defaultCommandIcons;
-	private HashSet<String> faqWords;
+	private HashSet<String> faqWords; 
 	
 	public MediusBotConfig(JSONObject json) {
 		this.json = json;
@@ -59,7 +59,7 @@ public class MediusBotConfig {
 				this.defaultCommandIcons.put(commandName, jsonDefaultCommandIcons.getString(commandName));
 			}
 		// Load Server
-		this.servers = new HashMap<String, MediusJQMServer>();
+		this.servers = new HashMap<String, MediusInformationClient>();
 		final JSONArray jsonServerArray = json.getJSONArray("servers");
 		final Iterator<Object> jsonServerIterator = jsonServerArray.iterator();
 		while (jsonServerIterator.hasNext()) {
@@ -81,7 +81,7 @@ public class MediusBotConfig {
 				commandIcons.put(commandName, jsonCmdIcons.getString(commandName));
 			}
 
-			final MediusJQMServer server = new MediusJQMServer(name, description, address, port, token, color, staticStatus, commandIcons);
+			final MediusInformationClient server = new MediusInformationClient(name, description, address, port, token, color, staticStatus, commandIcons);
 			servers.put(name, server);
 		}
 		
@@ -150,11 +150,11 @@ public class MediusBotConfig {
 
 	public void setFaqWords(HashSet<String> faqWords) { this.faqWords = faqWords; }
 
-	public HashMap<String, MediusJQMServer> getServers() {
+	public HashMap<String, MediusInformationClient> getServers() {
 		return servers;
 	}
 
-	public void setServers(HashMap<String, MediusJQMServer> servers) {
+	public void setServers(HashMap<String, MediusInformationClient> servers) {
 		this.servers = servers;
 	}
 	

--- a/src/main/java/net/hashsploit/mediusdiscordbot/MediusInformationClient.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/MediusInformationClient.java
@@ -1,0 +1,127 @@
+package net.hashsploit.mediusdiscordbot;
+
+import java.util.HashMap;
+
+import io.grpc.Channel;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import net.hashsploit.mediusdiscordbot.proto.MediusInformationGrpc;
+import net.hashsploit.mediusdiscordbot.proto.MediusInformationGrpc.MediusInformationBlockingStub;
+import net.hashsploit.mediusdiscordbot.proto.MediusStructures.StatusReq;
+import net.hashsploit.mediusdiscordbot.proto.MediusStructures.StatusListing;
+import net.hashsploit.mediusdiscordbot.proto.MediusStructures.StatusReq;
+import net.hashsploit.mediusdiscordbot.proto.MediusStructures.StatusRes;
+import net.hashsploit.mediusdiscordbot.proto.MediusStructures.StatusListing;
+
+
+public class MediusInformationClient{
+
+    // private final MediusInformationStub asyncStub;
+    private final MediusInformationBlockingStub blockingStub;
+    private final ManagedChannel grpcChannel;
+
+    private final String name;
+	private final String description;
+	private final String address;
+	private final int port;
+	private final String token;
+	private final int color;
+	private String staticStatus;
+    private final HashMap<String,String> commandIcons;
+    
+    public MediusInformationClient(final String name, final String description, final String address, final int port, final String token, final int color, final String staticStatus ,final HashMap<String, String> commandIcons) {
+		this.name = name;
+		this.description = description;
+		this.address = address;
+		this.port = port;
+		this.token = token;
+		this.color = color;
+		this.staticStatus = staticStatus;
+        this.commandIcons = commandIcons;
+
+        this.grpcChannel = ManagedChannelBuilder.forTarget(String.format("%s:%s", address, Integer.toString(port))).usePlaintext().build();
+        this.blockingStub = MediusInformationGrpc.newBlockingStub(this.grpcChannel);
+	}
+
+    /**
+	 * Get the Medius JQM server name.
+	 * @return
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Get the Medius JQM server description.
+	 * @return
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * Get the Medius JQM server address.
+	 * @return
+	 */
+	public String getAddress() {
+		return address;
+	}
+
+	/**
+	 * Get the Medius JQM server port.
+	 * @return
+	 */
+	public int getPort() {
+		return port;
+	}
+
+	/**
+	 * Get the Medius JQM server token.
+	 * @return
+	 */
+	public String getToken() {
+		return token;
+	}
+
+	/**
+	 * Get the server color.
+	 * @return
+	 */
+	public int getColor() {
+		return color;
+	}
+
+	/**
+	 * Get the Medius JQM static status message.
+	 */
+	public String getStaticStatus(){
+		return staticStatus;
+	}
+	
+	/**
+	 * Get the Medius JQM server command icons.
+	 */
+	public HashMap<String, String> getCommandIcons(){
+		return commandIcons;
+    }
+
+    //
+    //
+    //  MediusInformationm service GRPC client calls
+    //
+    //
+
+    public StatusRes GetStatus(StatusReq req){
+        StatusRes grpcRes = null;
+
+        try{
+            grpcRes = this.blockingStub.getStatus(req);
+        } catch(Exception e){
+            e.printStackTrace();
+        }
+
+        return grpcRes;
+    }
+
+
+}

--- a/src/main/java/net/hashsploit/mediusdiscordbot/util/TimedHashmap.java
+++ b/src/main/java/net/hashsploit/mediusdiscordbot/util/TimedHashmap.java
@@ -25,7 +25,7 @@ public class TimedHashmap <K,V> {
 
     public V get(K key) throws NullPointerException{
         if (!containsKey(key)){
-            throw new NullPointerException();
+            return null;
         }
         return hashmap.get(key).getSecond();
     }

--- a/src/main/proto/medius_structures.proto
+++ b/src/main/proto/medius_structures.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option java_package = "net.hashsploit.mediusdiscordbot.proto";
+
+service MediusInformation{
+    rpc GetStatus(StatusReq) returns (StatusRes) {}
+}
+
+
+message StatusListing{
+    string serverName = 1;
+    bool serverActive = 2;
+}
+
+message StatusReq{
+    string serverName = 1;
+}
+
+message StatusRes{
+    repeated StatusListing serverStatuses = 1;
+}


### PR DESCRIPTION
**pom.xml**: Updated to add grpc/protobuf dependencies
**proto/medius_structures.proto**: Current proto definitions (only have status defined currently)
**src/main/java/net/hashsploit/mediusdiscordbot/Command.java**: Update various var names to change from JQM => grpc denotions
**src/main/java/net/hashsploit/mediusdiscordbot/MediusBot.java**: Update various var names to change from JQM => grpc denotions
**src/main/java/net/hashsploit/mediusdiscordbot/MediusBotConfig.java**: Update various var names to change from JQM => grpc denotions
**src/main/java/net/hashsploit/mediusdiscordbot/MediusInformationClient.java**: GRPC client used by commmands to make mapped calls
**src/main/java/net/hashsploit/mediusdiscordbot/commands/StatusCommand.java**: Re-write to use GRPC and convert back from async => sync
**src/main/java/net/hashsploit/mediusdiscordbot/util/TimedHashmap.java**: Upon a key no longer being present, we return null. This allows us to avoid race conditions when trying to use cached information, in a simple manor
**src/main/proto/medius_structures.proto**: Current proto definitions, this is the actual proto file that is being compiled to grpc/ proto code (will remove the previous .proto above in a future commit)
